### PR TITLE
テーブル結合時のExit関数の実装を修正、Mysql等のみ対応

### DIFF
--- a/session_exist.go
+++ b/session_exist.go
@@ -35,6 +35,9 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 			}
 
 			tableName = session.statement.Engine.Quote(tableName)
+			if len(session.statement.JoinStr) > 0 {
+				joinStr = session.statement.JoinStr
+			}
 
 			if session.statement.cond.IsValid() {
 				condSQL, condArgs, err := builder.ToSQL(session.statement.cond)
@@ -47,8 +50,7 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 				} else if session.engine.dialect.DBType() == core.ORACLE {
 					sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE (%s) AND ROWNUM=1", tableName, condSQL)
 				} else {
-					if len(session.statement.JoinStr) > 0 {
-						joinStr = session.statement.JoinStr
+					if joinStr != "" {
 						sqlStr = fmt.Sprintf("SELECT * FROM %s %s WHERE %s LIMIT 1", tableName, joinStr, condSQL)
 					} else {
 						sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE %s LIMIT 1", tableName, condSQL)
@@ -61,8 +63,7 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 				} else if session.engine.dialect.DBType() == core.ORACLE {
 					sqlStr = fmt.Sprintf("SELECT * FROM  %s WHERE ROWNUM=1", tableName)
 				} else {
-					if len(session.statement.JoinStr) > 0 {
-						joinStr = session.statement.JoinStr
+					if joinStr != "" {
 						sqlStr = fmt.Sprintf("SELECT * FROM %s %s LIMIT 1", tableName, joinStr)
 					} else {
 						sqlStr = fmt.Sprintf("SELECT * FROM %s LIMIT 1", tableName)

--- a/session_exist.go
+++ b/session_exist.go
@@ -25,8 +25,8 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 
 	var sqlStr string
 	var args []interface{}
+	var joinStr string
 	var err error
-
 	if session.statement.RawSQL == "" {
 		if len(bean) == 0 {
 			tableName := session.statement.TableName()
@@ -47,7 +47,12 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 				} else if session.engine.dialect.DBType() == core.ORACLE {
 					sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE (%s) AND ROWNUM=1", tableName, condSQL)
 				} else {
-					sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE %s LIMIT 1", tableName, condSQL)
+					if len(session.statement.JoinStr) > 0 {
+						joinStr = session.statement.JoinStr
+						sqlStr = fmt.Sprintf("SELECT * FROM %s %s WHERE %s LIMIT 1", tableName, joinStr, condSQL)
+					} else {
+						sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE %s LIMIT 1", tableName, condSQL)
+					}
 				}
 				args = condArgs
 			} else {
@@ -56,7 +61,12 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 				} else if session.engine.dialect.DBType() == core.ORACLE {
 					sqlStr = fmt.Sprintf("SELECT * FROM  %s WHERE ROWNUM=1", tableName)
 				} else {
-					sqlStr = fmt.Sprintf("SELECT * FROM %s LIMIT 1", tableName)
+					if len(session.statement.JoinStr) > 0 {
+						joinStr = session.statement.JoinStr
+						sqlStr = fmt.Sprintf("SELECT * FROM %s %s LIMIT 1", tableName, joinStr)
+					} else {
+						sqlStr = fmt.Sprintf("SELECT * FROM %s LIMIT 1", tableName)
+					}
 				}
 				args = []interface{}{}
 			}

--- a/session_exist_test.go
+++ b/session_exist_test.go
@@ -168,4 +168,11 @@ func TestExistStructForJoin(t *testing.T) {
 		Join("LEFT", "empsetting", "empsetting.id = check_list.eid")
 	_, err = session.Exist()
 	assert.Error(t, err)
+
+	session.Table("salary").
+		Select("empsetting.id").
+		Join("LEFT", "empsetting", "empsetting.id = salary.lid")
+	has, err = session.Exist()
+	assert.NoError(t, err)
+	assert.True(t, has)
 }

--- a/session_exist_test.go
+++ b/session_exist_test.go
@@ -74,3 +74,98 @@ func TestExistStruct(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, has)
 }
+
+func TestExistStructForJoin(t *testing.T) {
+	assert.NoError(t, prepareEngine())
+
+	type Salary struct {
+		Id  int64
+		Lid int64
+	}
+
+	type CheckList struct {
+		Id  int64
+		Eid int64
+	}
+
+	type Empsetting struct {
+		Id   int64
+		Name string
+	}
+
+	assert.NoError(t, testEngine.Sync2(new(Salary), new(CheckList), new(Empsetting)))
+
+	var emp Empsetting
+	cnt, err := testEngine.Insert(&emp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, cnt)
+
+	var checklist = CheckList{
+		Eid: emp.Id,
+	}
+	cnt, err = testEngine.Insert(&checklist)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, cnt)
+
+	var salary = Salary{
+		Lid: checklist.Id,
+	}
+	cnt, err = testEngine.Insert(&salary)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, cnt)
+
+	session := testEngine.NewSession()
+	defer session.Close()
+
+	session.Table("salary").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid").
+		Where("salary.lid = ?", 1)
+	has, err := session.Exist()
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	session.Table("salary").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid").
+		Where("salary.lid = ?", 2)
+	has, err = session.Exist()
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	session.Table("salary").
+		Select("check_list.id").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid").
+		Where("check_list.id = ?", 1)
+	has, err = session.Exist()
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	session.Table("salary").
+		Select("empsetting.id").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid").
+		Where("empsetting.id = ?", 2)
+	has, err = session.Exist()
+	assert.NoError(t, err)
+	assert.False(t, has)
+
+	session.Table("salary").
+		Select("empsetting.id").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid")
+	has, err = session.Exist()
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	err = session.DropTable("check_list")
+	assert.NoError(t, err)
+
+	session.Table("salary").
+		Select("empsetting.id").
+		Join("INNER", "check_list", "check_list.id = salary.lid").
+		Join("LEFT", "empsetting", "empsetting.id = check_list.eid")
+	_, err = session.Exist()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
- テーブル結合時にExit()を使うと結合条件をスルーしてクエリ実行していたので、結合条件を含めて実行するよう修正。
- 自分用なのでいったんmysql等のみ対応